### PR TITLE
feat(scully-plugin-angular-delay): adding support for overriding tsconfig and dist folder paths

### DIFF
--- a/libs/scully-plugin-angular-delay/README.md
+++ b/libs/scully-plugin-angular-delay/README.md
@@ -47,12 +47,13 @@ export const config: ScullyConfig = {
 };
 ```
 
-- If your tsconfig lives outside of the scully project root, you can specify the path to the tsconfig.json
+- If your tsconfig or dist folder lives outside of the scully project root, you can specify the paths
 
 ```javascript
 const postRenderers = [
   getDelayAngularPlugin({
-    tsConfigPath: '../../tsconfig.json'
+    tsConfigPath: '../../tsconfig.json',
+    distFolder: '../../dist/app'
   })
 ];
 ```

--- a/libs/scully-plugin-angular-delay/README.md
+++ b/libs/scully-plugin-angular-delay/README.md
@@ -47,6 +47,16 @@ export const config: ScullyConfig = {
 };
 ```
 
+- If your tsconfig lives outside of the scully project root, you can specify the path to the tsconfig.json
+
+```javascript
+const postRenderers = [
+  getDelayAngularPlugin({
+    tsConfigPath: '../../tsconfig.json'
+  })
+];
+```
+
 _Build your app with the `--stats-json` flag enabled as the plugin needs to know which assets have been build for your app. Then just run the Scully command._
 
 ```bash

--- a/libs/scully-plugin-angular-delay/src/lib/scully-plugin-angular-delay.ts
+++ b/libs/scully-plugin-angular-delay/src/lib/scully-plugin-angular-delay.ts
@@ -10,16 +10,19 @@ interface DelayAngularPluginOptions {
   routesBlacklist?: { route: string; removeAngular?: boolean }[];
   delayMilliseconds?: number;
   tsConfigPath?: string;
+  distFolder?: string;
 }
 
 let RoutesBlacklist = [];
 let DelayMilliseconds = 0;
 let TSConfigPath: string | null = null;
+let DistFolder: string | null = null;
 
 export function getDelayAngularPlugin({
   routesBlacklist,
   delayMilliseconds,
-  tsConfigPath
+  tsConfigPath,
+  distFolder
 }: DelayAngularPluginOptions = {}) {
   if (routesBlacklist) {
     RoutesBlacklist = routesBlacklist;
@@ -29,6 +32,9 @@ export function getDelayAngularPlugin({
   }
   if (tsConfigPath) {
     TSConfigPath = tsConfigPath;
+  }
+  if (distFolder) {
+    DistFolder = distFolder;
   }
 
   return DelayAngular;
@@ -63,11 +69,12 @@ async function delayAngularPlugin(html, routeObj) {
     readFileSync(tsConfigPath, { encoding: 'utf8' }).toString()
   );
 
+  const distFolder = (DistFolder) ? DistFolder : scullyConfig.distFolder;
   let isEs5Config = false;
-  let statsJsonPath = join(scullyConfig.distFolder, 'stats-es2015.json');
+  let statsJsonPath = join(distFolder, 'stats-es2015.json');
   if (tsConfig.compilerOptions.target === 'es5') {
     isEs5Config = true;
-    statsJsonPath = join(scullyConfig.distFolder, 'stats.json');
+    statsJsonPath = join(distFolder, 'stats.json');
   }
 
   if (!existsSync(statsJsonPath)) {
@@ -80,7 +87,7 @@ Please run 'ng build' with the '--stats-json' flag`;
   }
 
   const scullyDelayAngularStatsJsonPath = join(
-    scullyConfig.distFolder,
+    distFolder,
     'scully-plugin-angular-delay-stats.json'
   );
   let scullyDelayAngularStatsJson = [];

--- a/libs/scully-plugin-angular-delay/src/lib/scully-plugin-angular-delay.ts
+++ b/libs/scully-plugin-angular-delay/src/lib/scully-plugin-angular-delay.ts
@@ -9,20 +9,26 @@ registerPlugin('render', DelayAngular, delayAngularPlugin);
 interface DelayAngularPluginOptions {
   routesBlacklist?: { route: string; removeAngular?: boolean }[];
   delayMilliseconds?: number;
+  tsConfigPath?: string;
 }
 
 let RoutesBlacklist = [];
 let DelayMilliseconds = 0;
+let TSConfigPath: string | null = null;
 
 export function getDelayAngularPlugin({
   routesBlacklist,
-  delayMilliseconds
+  delayMilliseconds,
+  tsConfigPath
 }: DelayAngularPluginOptions = {}) {
   if (routesBlacklist) {
     RoutesBlacklist = routesBlacklist;
   }
   if (delayMilliseconds) {
     DelayMilliseconds = delayMilliseconds;
+  }
+  if (tsConfigPath) {
+    TSConfigPath = tsConfigPath;
   }
 
   return DelayAngular;
@@ -40,9 +46,14 @@ async function delayAngularPlugin(html, routeObj) {
   if (blacklistRoute && !blacklistRoute.removeAngular) {
     return Promise.resolve(html);
   }
-  const tsConfigPath = scullyConfig.projectRoot
-    ? join(scullyConfig.projectRoot, 'tsconfig.json')
-    : 'tsconfig.json';
+  let tsConfigPath: string;
+  if (TSConfigPath) {
+    tsConfigPath = TSConfigPath;
+  } else {
+    tsConfigPath = scullyConfig.projectRoot
+      ? join(scullyConfig.projectRoot, 'tsconfig.json')
+      : 'tsconfig.json';
+  }
   if (!existsSync(tsConfigPath)) {
     const notsconfigError = `No tsconfig file ${tsConfigPath} found`;
     console.error(notsconfigError);
@@ -62,7 +73,7 @@ async function delayAngularPlugin(html, routeObj) {
   if (!existsSync(statsJsonPath)) {
     const noStatsJsonError = `A ${
       isEs5Config ? 'stats' : 'stats-es2015'
-    }.json is required for the 'delayAngular' plugin.
+      }.json is required for the 'delayAngular' plugin.
 Please run 'ng build' with the '--stats-json' flag`;
     console.error(noStatsJsonError);
     throw new Error(noStatsJsonError);
@@ -169,7 +180,7 @@ Please run 'ng build' with the '--stats-json' flag`;
       }
       html = html.replace(regex, '');
     });
-    scriptsArray.forEach(function(x, index) {
+    scriptsArray.forEach(function (x, index) {
       if (x.startsWith('runtime')) {
         sorted.splice(0, 0, x);
       } else if (x.startsWith('main')) {


### PR DESCRIPTION
Details: Adding the ability to specify a path for the tsconfig.json and distFolder. This is important for yarn monorepos where the folder structure may differ. Readme was updated to reflect additional options.

Breaking Changes: Should be no breaking changes.

Fixes/Feature #24

- [x] yarn affected:test succeeds
- [x] yarn affected:e2e succeeds
- [x] yarn format:check succeeds
- [x] Code coverage does not decrease (if any source code was changed)
- [] If applicable, appropriate Wiki docs were updated (if applicable)
- [] If applicable, code review comments are written in the source code with / {Name}

