### PR TITLE
fix(scully-plugin-angular-delay): Load JS files

### DIFF
--- a/libs/scully-plugin-angular-delay/src/lib/scully-plugin-angular-delay.ts
+++ b/libs/scully-plugin-angular-delay/src/lib/scully-plugin-angular-delay.ts
@@ -207,7 +207,7 @@ Please run 'ng build' with the '--stats-json' flag`;
         sorted = sorted.concat(otherJs);
       }
     });
-    appendScript += `scriptsToLoad = '${JSON.stringify(sorted)}'`;
+    appendScript += `scriptsToLoad = ${JSON.stringify(sorted)}`;
     const dom = new JSDOM(html);
     const doc = dom.window.document;
     const s = doc.createElement('script');


### PR DESCRIPTION
fix(scully-plugin-angular-delay): Load JS files

Currently get error `Uncaught TypeError: scriptsToLoad.forEach is not a function`. This is due to forEach on a string.

closes #34

Details: <details_of_the_pull_request_goes_here>

Breaking Changes: <if_applicable_details_of_breaking_changes_goes_here>

Fixes/Feature #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] yarn affected:test succeeds
- [ ] yarn affected:e2e succeeds
- [ ] yarn format:check succeeds
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] If applicable, appropriate Wiki docs were updated (if applicable)
- [ ] If applicable, code review comments are written in the source code with / {Name}
