### PR TITLE
fix(nx-serverless): nx deploy throw warning when checking dependencies

### DIFF
--- a/libs/nx-serverless/src/utils/normalize.ts
+++ b/libs/nx-serverless/src/utils/normalize.ts
@@ -256,7 +256,7 @@ export function getProdModules(
       // Check if the module has any peer dependencies and include them too
       try {
         const modulePackagePath = join(
-          dirname(join(process.cwd(), packagePath)),
+          dirname(packagePath),
           'node_modules',
           module.external,
           'package.json'
@@ -270,6 +270,7 @@ export function getProdModules(
           const peerModules = this.getProdModules.call(
             this,
             _.map(peerDependencies, (value, key) => ({ external: key })),
+            packageJson,
             packagePath,
             dependencyGraph,
             forceExcludes


### PR DESCRIPTION
* Fix wrong module path calculator when checking peer dependencies for external module
* Add missing packageJson parameter when calling getProdModules function

Fixes #36
