### PR TITLE
fix(nx-serverless): node arguments incorrectly passed to serverless command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /out-tsc
 
 # dependencies
-/node_modules
+node_modules/
 
 # IDEs and editors
 /.idea

--- a/libs/nx-serverless/src/builders/offline/offline.impl.ts
+++ b/libs/nx-serverless/src/builders/offline/offline.impl.ts
@@ -135,7 +135,7 @@ function startBuild(
 }
 
 function getExecArgv(options: ServerlessExecuteBuilderOptions) {
-  const args = ['-r', 'source-map-support/register'];
+  const args = [];
   if (options.inspect === true) {
     options.inspect = InspectType.Inspect;
   }


### PR DESCRIPTION
Details: The nx-serverless plugin was passing "-r source-map-support/register", which is a node executable argument, incorrectly to the serverless execcuable, which functions as a region override, which causes issues with some serverless plugins.

Breaking Changes: none

Fixes/Feature #46

- [x] yarn affected:test succeeds
- [x] yarn affected:e2e succeeds
- [x] yarn format:check succeeds
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] If applicable, appropriate Wiki docs were updated (if applicable)
- [ ] If applicable, code review comments are written in the source code with / {Name}
