### PR TITLE
Fix/use correct package manager

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -22,9 +22,18 @@ module.exports = {
     { name: 'docs', description: 'anything related to docs infrastructure' },
     { name: 'nx-aws-cdk', description: 'anything aws-cdk specific' },
     { name: 'angular', description: 'anything angular specific' },
-    { name: 'scully-plugin-angular-delay', description: 'anything scully-plugin-angular-delay specific' },
-    { name: 'scully-plugin-google-analytics', description: 'anything scully-plugin-google-analytics specific' },
-    { name: 'scully-plugin-lazy-load-picture-tag', description: 'anything scully-plugin-lazy-load-picture-tag specific' },
+    {
+      name: 'scully-plugin-angular-delay',
+      description: 'anything scully-plugin-angular-delay specific'
+    },
+    {
+      name: 'scully-plugin-google-analytics',
+      description: 'anything scully-plugin-google-analytics specific'
+    },
+    {
+      name: 'scully-plugin-lazy-load-picture-tag',
+      description: 'anything scully-plugin-lazy-load-picture-tag specific'
+    },
     { name: 'node', description: 'anything Node specific' },
     { name: 'linter', description: 'anything Linter specific' },
     {

--- a/libs/nx-serverless/migrations.json
+++ b/libs/nx-serverless/migrations.json
@@ -1,5 +1,3 @@
 {
-    "schematics": {
-       
-    }
+  "schematics": {}
 }

--- a/libs/nx-serverless/package.json
+++ b/libs/nx-serverless/package.json
@@ -40,7 +40,8 @@
     "depcheck": "0.9.2",
     "serverless": "^1.66.0",
     "is-builtin-module": "^3.0.0",
-    "ignore": "5.0.4"
+    "ignore": "5.0.4",
+    "detect-package-manager": "^1.1.0"
   },
   "devDependencies": {},
   "repository": {

--- a/libs/nx-serverless/src/utils/packagers/package-manager.spec.ts
+++ b/libs/nx-serverless/src/utils/packagers/package-manager.spec.ts
@@ -1,0 +1,35 @@
+import { packageManagerFactory } from './package-manager';
+import { NPM } from './npm';
+import { Yarn } from './yarn';
+import { dirname } from 'path';
+
+const packageJsonPath = dirname('dist/apps/serverlessapp/package.json');
+
+describe('PackageManger', () => {
+  describe('packageManagerFactory', () => {
+    it('should return null when package manager is not supported', () => {
+      packageManagerFactory(
+        packageJsonPath,
+        'unknown-package-manager'
+      ).then(packageManager => expect(packageManager).toBeNull());
+    });
+
+    it('should return NPM when package manager', () => {
+      packageManagerFactory(packageJsonPath, 'npm').then(packageManager =>
+        expect(packageManager).toBeInstanceOf(NPM)
+      );
+    });
+
+    it('should return YARN when package manager', () => {
+      packageManagerFactory(packageJsonPath, 'yarn').then(packageManager =>
+        expect(packageManager).toBeInstanceOf(Yarn)
+      );
+    });
+
+    it('should return YARN or NPM when empty constructor', () => {
+      packageManagerFactory(packageJsonPath).then(packageManager =>
+        expect(packageManager).toBeInstanceOf(Yarn || NPM)
+      );
+    });
+  });
+});

--- a/libs/nx-serverless/src/utils/packagers/package-manager.ts
+++ b/libs/nx-serverless/src/utils/packagers/package-manager.ts
@@ -1,0 +1,59 @@
+import * as _ from 'lodash';
+import { NPM } from './npm';
+import { Yarn } from './yarn';
+import * as detectPackageManager from 'detect-package-manager';
+import { SpawnSyncReturns } from 'child_process';
+import { OperatorFunction } from 'rxjs';
+
+const registeredPackagers = { npm: NPM, yarn: Yarn };
+
+export async function packageManagerFactory(
+  cwd: string,
+  packageManagerId?: string
+): Promise<PackageManager> {
+  const packageManagerOnSystem = await detectPackageManager(cwd);
+
+  const packageManager = packageManagerId
+    ? packageManagerId.toLowerCase()
+    : packageManagerOnSystem;
+
+  if (!_.has(registeredPackagers, packageManager)) {
+    return null;
+  }
+
+  return new registeredPackagers[packageManager]();
+}
+
+export interface PackageManagerInstallOptions {
+  ignoreScripts: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PackageManagerPruneOptions
+  extends PackageManagerInstallOptions {}
+
+export interface PackageManager {
+  name: string;
+  lockfileName: string;
+  copyPackageSectionNames: Array<string>;
+  mustCopyModules: boolean;
+
+  getProdDependencies(cwd: string, depth: number): SpawnSyncReturns<Buffer>;
+
+  install(
+    cwd: string,
+    options?: PackageManagerInstallOptions
+  ): SpawnSyncReturns<Buffer>;
+
+  prune(
+    cwd: string,
+    options?: PackageManagerInstallOptions
+  ): SpawnSyncReturns<Buffer>;
+
+  runScripts(
+    cwd: string,
+    scriptNames: (value: string, index: number) => SpawnSyncReturns<Buffer>
+  ): OperatorFunction<string, SpawnSyncReturns<Buffer>>;
+
+  generateLockFile(cwd: string): SpawnSyncReturns<Buffer>;
+}

--- a/libs/scully-plugin-angular-delay/src/lib/scully-plugin-angular-delay.ts
+++ b/libs/scully-plugin-angular-delay/src/lib/scully-plugin-angular-delay.ts
@@ -69,7 +69,7 @@ async function delayAngularPlugin(html, routeObj) {
     readFileSync(tsConfigPath, { encoding: 'utf8' }).toString()
   );
 
-  const distFolder = (DistFolder) ? DistFolder : scullyConfig.distFolder;
+  const distFolder = DistFolder ? DistFolder : scullyConfig.distFolder;
   let isEs5Config = false;
   let statsJsonPath = join(distFolder, 'stats-es2015.json');
   if (tsConfig.compilerOptions.target === 'es5') {
@@ -80,7 +80,7 @@ async function delayAngularPlugin(html, routeObj) {
   if (!existsSync(statsJsonPath)) {
     const noStatsJsonError = `A ${
       isEs5Config ? 'stats' : 'stats-es2015'
-      }.json is required for the 'delayAngular' plugin.
+    }.json is required for the 'delayAngular' plugin.
 Please run 'ng build' with the '--stats-json' flag`;
     console.error(noStatsJsonError);
     throw new Error(noStatsJsonError);
@@ -187,7 +187,7 @@ Please run 'ng build' with the '--stats-json' flag`;
       }
       html = html.replace(regex, '');
     });
-    scriptsArray.forEach(function (x, index) {
+    scriptsArray.forEach(function(x, index) {
       if (x.startsWith('runtime')) {
         sorted.splice(0, 0, x);
       } else if (x.startsWith('main')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3801,6 +3801,14 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
+detect-package-manager@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-package-manager/-/detect-package-manager-1.1.0.tgz#af05738105d30cf99eb8578f90747652a94cbae1"
+  integrity sha512-/Zxr1vXrlTDs/07xCNTYwN4UYAS8C5LZoQNMEpwstC3tvbAmlk/JW6dsdl7bZMkPsBWMWiLznIjoF2pah4nrUQ==
+  dependencies:
+    execa "^0.8.0"
+    path-exists "^3.0.0"
+
 detective-amd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/detective-amd/-/detective-amd-3.0.0.tgz#40c8e21e229df8bca1ee2d4b952a7b67b01e2a5a"
@@ -4501,6 +4509,19 @@ execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
   integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"


### PR DESCRIPTION
Details: 
The code before did not detect which package manager that should be used.
Instead it just checked if 'yarn' was allowed to use. 

This code will first check if `package-lock.json` or `yarn.lock` file exists. If that is not possible the package `detect-package-manager` will try to execute the `npm` and `yarn` commands to determine if it is installed. 

**NOTE** Having some issues running the `yarn affected:e2e` command locally so i am not able to test this solution out from a users perspective. Would be nice with some help here.

Another thing is that we really should write some tests for the implementation of the package manager. Right now i am not sure if `NPM.ts` and `Yarn.ts` works as expected.

Breaking Changes:
Well i guess there is a breaking change since it will work differently. But since the code already was breaking i am not sure if this is better or worse 👍 

Fixes/Feature #50 

- [x] yarn affected:test succeeds
- [ ] yarn affected:e2e succeeds
- [x] yarn format:check succeeds
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] If applicable, appropriate Wiki docs were updated (if applicable)
- [ ] If applicable, code review comments are written in the source code with / {Name}
