### PR TITLE
fix(nx-serverless): allow & ignore additional options for offline builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://angular.io/assets/images/logos/angular/angular.svg" height="145">
 <!-- <img src="https://angular.io/generated/images/marketing/concept-icons/universal.png" height="120"> -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Node.js_logo.svg" height="145">
-<img src="https://github.com/scullyio/scully/raw/master/assets/logos/PNG/scullyio-logo.png" height="145">
+<img src="https://raw.githubusercontent.com/scullyio/scully/main/assets/logos/PNG/scullyio-logo.png" height="145">
 </p>
 
 <div align="left">

--- a/libs/nx-serverless/src/builders/offline/schema.json
+++ b/libs/nx-serverless/src/builders/offline/schema.json
@@ -33,6 +33,6 @@
       "description": "The port to inspect the process on. Setting port to 0 will assign random free ports to all forked processes."
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["buildTarget", "config", "location"]
 }


### PR DESCRIPTION
Details: Prevents failures if nx-serverless offline is passed unknown options, instead silently ignoring them.  Allows the usage of nx-serverless with the built in nx cypress implementation for making e2e tests on the api layer

Breaking Changes: n/a

Fixes/Feature #68 

- [x] yarn affected:test succeeds
- [x] yarn affected:e2e succeeds
- [x] yarn format:check succeeds
- [x] Code coverage does not decrease (if any source code was changed)
- [x] If applicable, appropriate Wiki docs were updated (if applicable)
- [x] If applicable, code review comments are written in the source code with / {Name}
