### PR TITLE
Feature/support serverless 2

### DIFF
--- a/libs/nx-serverless/README.md
+++ b/libs/nx-serverless/README.md
@@ -55,10 +55,11 @@ Simplify any workflow that can be abstracted into one command using the same con
 | Serverless-offline | :white_check_mark: | :calendar: | :calendar: |
 
 ### Supported Serverless Framework Versions
-| Versions | Status            |
-| -------- | ----------------- |
-| 1.0+     | :white_check_mark:|
-| 2.0+     | :white_check_mark:|
+
+| Versions | Status             |
+| -------- | ------------------ |
+| 1.0+     | :white_check_mark: |
+| 2.0+     | :white_check_mark: |
 
 ### Builders wrapped before packaging/deployment
 

--- a/libs/nx-serverless/README.md
+++ b/libs/nx-serverless/README.md
@@ -54,6 +54,12 @@ Simplify any workflow that can be abstracted into one command using the same con
 | Sls Command        | :white_check_mark: | :calendar: | :calendar: |
 | Serverless-offline | :white_check_mark: | :calendar: | :calendar: |
 
+### Supported Serverless Framework Versions
+| Versions | Status            |
+| -------- | ----------------- |
+| 1.0+     | :white_check_mark:|
+| 2.0+     | :white_check_mark:|
+
 ### Builders wrapped before packaging/deployment
 
 | Builder Names       |                    |

--- a/libs/nx-serverless/package.json
+++ b/libs/nx-serverless/package.json
@@ -38,7 +38,7 @@
     "webpack-dev-server": "3.9.0",
     "webpack-node-externals": "1.7.2",
     "depcheck": "0.9.2",
-    "serverless": "^1.66.0",
+    "serverless": "^2.29.0",
     "is-builtin-module": "^3.0.0",
     "ignore": "5.0.4"
   },

--- a/libs/nx-serverless/src/schematics/angular-universal/application.ts
+++ b/libs/nx-serverless/src/schematics/angular-universal/application.ts
@@ -167,7 +167,7 @@ function addServerlessYMLFile(options: NormalizedSchema): Rule {
     host.create(
       join(options.appProjectRoot, 'serverless.yml'),
       `service: ${options.project}
-frameworkVersion: ">=1.1.0 <2.0.0"
+frameworkVersion: ">=1.1.0"
 plugins:
   - serverless-offline
   - serverless-apigw-binary

--- a/libs/nx-serverless/src/schematics/api/api.ts
+++ b/libs/nx-serverless/src/schematics/api/api.ts
@@ -131,7 +131,7 @@ function addServerlessYMLFile(options: NormalizedSchema): Rule {
     host.create(
       join(options.appProjectRoot, 'serverless.yml'),
       `service: ${options.name}
-frameworkVersion: ">=1.1.0 <2.0.0"
+frameworkVersion: ">=1.1.0"
 plugins:
   - serverless-offline
 package:

--- a/libs/nx-serverless/src/schematics/express/application.ts
+++ b/libs/nx-serverless/src/schematics/express/application.ts
@@ -165,7 +165,7 @@ function addServerlessYMLFile(options: NormalizedSchema): Rule {
     host.create(
       join(options.appProjectRoot, 'serverless.yml'),
       `service: ${options.name}
-frameworkVersion: ">=1.1.0 <2.0.0"
+frameworkVersion: ">=1.1.0"
 plugins:
   - serverless-offline
   - serverless-apigw-binary

--- a/libs/nx-serverless/src/schematics/scully/application.ts
+++ b/libs/nx-serverless/src/schematics/scully/application.ts
@@ -118,7 +118,7 @@ function addServerlessYMLFile(options: NormalizedSchema): Rule {
     host.create(
       join(options.appProjectRoot, 'serverless.yml'),
       `service: ${options.project}
-frameworkVersion: ">=1.1.0 <2.0.0"
+frameworkVersion: ">=1.1.0"
 plugins:
   - serverless-offline
   - serverless-apigw-binary

--- a/libs/nx-serverless/src/utils/serverless.ts
+++ b/libs/nx-serverless/src/utils/serverless.ts
@@ -80,7 +80,10 @@ export class ServerlessWrapper {
             config: options.serverlessConfig,
             servicePath: options.servicePath
           });
-          if (this.serverless$.version && this.serverless$.version.split('.')[0] > '1') {
+          if (
+            this.serverless$.version &&
+            this.serverless$.version.split('.')[0] > '1'
+          ) {
             context.logger.info(
               'Disable "Resolve Configuration Internally" for serverless 2.0+.'
             );

--- a/libs/nx-serverless/src/utils/serverless.ts
+++ b/libs/nx-serverless/src/utils/serverless.ts
@@ -80,6 +80,13 @@ export class ServerlessWrapper {
             config: options.serverlessConfig,
             servicePath: options.servicePath
           });
+          if (this.serverless$.version && this.serverless$.version.split('.')[0] > '1') {
+            context.logger.info(
+              'Disable "Resolve Configuration Internally" for serverless 2.0+.'
+            );
+            this.serverless$._shouldResolveConfigurationInternally = false;
+            this.serverless$.configurationPath = options.serverlessConfig;
+          }
           return this.serverless$.init();
         }),
         concatMap(() => {


### PR DESCRIPTION
Details: Support Serverless 2.0

Breaking Changes: 
1. Set configurationPath after instancing the Serverless object.
2. Disable "Resolve Configuration Interally" for Serverless 2+  because it overwrites the configurationpath with `pwd()`. Please note this change will not be necessary after Serverless 3+/

Fixes/Feature #<issue_number_goes_here> 
#75 

- [x] yarn affected:test succeeds
- [x] yarn affected:e2e succeeds
- [x] yarn format:check succeeds
- [x] Code coverage does not decrease (if any source code was changed)
- [x] If applicable, appropriate Wiki docs were updated (if applicable)
- [ ] If applicable, code review comments are written in the source code with / {Name}
