### PR TITLE
fix(nx-serverless): respecting serverless config option when resolving config internally

### DIFF
--- a/libs/nx-serverless/src/utils/serverless.ts
+++ b/libs/nx-serverless/src/utils/serverless.ts
@@ -94,7 +94,7 @@ export class ServerlessWrapper {
             );
             this.serverless$._shouldResolveConfigurationInternally = false;
             this.serverless$.serviceDir = options.servicePath;
-            this.serverless$.configurationFilename = 'serverless.yml';
+            this.serverless$.configurationFilename = options.serverlessConfig;
             this.serverless$.config.commands = [
               'deploy',
               'offline',


### PR DESCRIPTION
Details: When resolving configuration internally for serverless 2+, the serverlessConfig option was not being utilized.
