### PR TITLE
feat(nx-serverless): fix bug not able to find external dependencies

### DIFF
--- a/libs/nx-serverless/src/utils/webpack.stats.ts
+++ b/libs/nx-serverless/src/utils/webpack.stats.ts
@@ -59,19 +59,12 @@ export class WebpackDependencyResolver implements DependencyResolver {
       return [];
     }
     const externals = new Set();
-    for (const chunk of stats.chunks) {
-      if (!chunk.modules) {
-        continue;
-      }
-
-      // Explore each module within the chunk (built inputs):
-      for (const module of chunk.modules) {
-        if (this.isExternalModule(module)) {
-          externals.add({
-            origin: module.issuer,
-            external: this.getExternalModuleName(module),
-          });
-        }
+    for (const mod of stats.modules) {
+      if (this.isExternalModule(mod)) {
+        externals.add({
+            origin: mod.issuer,
+            external: this.getExternalModuleName(mod),
+        });
       }
     }
     return Array.from(externals);


### PR DESCRIPTION
This bug results in no dependencies in package.json when deploy command is executed.

Details: 

After importing, node-fetch from handler.ts, while build command works fine, deploy command ignores all external dependencies and never included them to zip file.

I'm not sure why this is happening, because package.json of nx-plugins seems to have all fixed versions of webpacks.
That shouldn't have change the data shape of the stats returned from webpack.

Anyhow, after console logging the data of webpack stats,
I had to update the `WebpackDependencyResolver .getExternalModules` in order to include dependecies.

Breaking Changes: 
Well.. your test were already failing many specs... at this point I'm not sure how this change will effect in other nx version.
I'm currently using `12.6.4`
Perhaps having automated testing for handler with external dependencies would be good idea.


Fixes/Feature #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] yarn affected:test succeeds
- [ ] yarn affected:e2e succeeds
- [ ] yarn format:check succeeds
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] If applicable, appropriate Wiki docs were updated (if applicable)
- [ ] If applicable, code review comments are written in the source code with / {Name}
