### PR TITLE
Use lowercase to ignore also accept upper case YARN and NPM

### DIFF
--- a/libs/nx-serverless/src/utils/packagers/index.ts
+++ b/libs/nx-serverless/src/utils/packagers/index.ts
@@ -75,9 +75,9 @@ export function preparePackageJson(
   logger.info('create a package.json with first level dependencies'); //First create a package.json with first level dependencies
   // Get the packager for the current process.
   let packagerInstance = null;
-  if (options.packager && options.packager == 'npm') {
+  if (options.packager && options.packager.toLowerCase() == 'npm') {
     packagerInstance = NPM;
-  } else if (options.packager && options.packager == 'yarn') {
+  } else if (options.packager && options.packager.toLowerCase() == 'yarn') {
     packagerInstance = Yarn;
   } else if (packager('npm')) {
     packagerInstance = NPM;

--- a/libs/nx-serverless/src/utils/packagers/index.ts
+++ b/libs/nx-serverless/src/utils/packagers/index.ts
@@ -75,9 +75,9 @@ export function preparePackageJson(
   logger.info('create a package.json with first level dependencies'); //First create a package.json with first level dependencies
   // Get the packager for the current process.
   let packagerInstance = null;
-  if (options.packager && options.packager.toLowerCase() == 'npm') {
+  if (options.packager && options.packager.toLowerCase() === 'npm') {
     packagerInstance = NPM;
-  } else if (options.packager && options.packager.toLowerCase() == 'yarn') {
+  } else if (options.packager && options.packager.toLowerCase() === 'yarn') {
     packagerInstance = Yarn;
   } else if (packager('npm')) {
     packagerInstance = NPM;


### PR DESCRIPTION
Right now using yarn as package manager is not working to wrong comparison of the name string. 

This results in completely ignoring of package versions and fall back to latest version. This especially bad when the latest version of a package can not be used, and results in a complete failure of the lambda funcions (e.g. elasticsearch package)