### PR TITLE
fix(nx-serverless): set serviceDir earlier in the deploy process

### DIFF
--- a/libs/nx-serverless/src/utils/serverless.ts
+++ b/libs/nx-serverless/src/utils/serverless.ts
@@ -123,12 +123,8 @@ export class ServerlessWrapper {
         serviceDir: buildOptions.servicePath,
         configurationFilename: configFileName,
       };
-      if (
-        deployOptions &&
-        deployOptions.function &&
-        deployOptions.function != ''
-      ) {
-        serverlessConfig.servicePath = getPackagePath(deployOptions);
+      if (deployOptions) {
+        serverlessConfig.serviceDir = getPackagePath(deployOptions);
       }
       this.serverless$ = new Serverless(serverlessConfig);
       // if (componentsV2.runningComponents()) return () => componentsV2.runComponents();


### PR DESCRIPTION
Details: Sets `serviceDir` properly during init step for deploy commands, this fixes an issue when using a single zip artifact for deploy.

Breaking Changes: This may affect the recently added function based deploys

Fixes/Feature #82
- [ ] yarn affected:test succeeds
- [ ] yarn affected:e2e succeeds
- [x] yarn format:check succeeds
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] If applicable, appropriate Wiki docs were updated (if applicable)
- [ ] If applicable, code review comments are written in the source code with / {Name}
